### PR TITLE
Lazy torrent table rendering

### DIFF
--- a/frontend/src/Init.elm
+++ b/frontend/src/Init.elm
@@ -30,6 +30,7 @@ init flags =
     in
     ( { config = config
       , rtorrentSystemInfo = Nothing
+      , top = 0
       , dnd = (dndSystemTorrent Model.Table.Torrents).model
       , websocketConnected = False
       , contextMenu = Nothing

--- a/frontend/src/Model.elm
+++ b/frontend/src/Model.elm
@@ -26,9 +26,18 @@ import Model.Window
 import Time
 
 
+type alias ScrollEvent =
+    { scrollTop : Float
+    , scrollHeight : Float
+    , scrollLeft : Float
+    , scrollWidth : Float
+    }
+
+
 type Msg
     = NoOp
     | SetTimeZone Time.Zone
+    | Scroll ScrollEvent
     | MouseDown Attribute MousePosition Mouse.Button Mouse.Keys
     | AttributeResized Model.Table.ResizeOp MousePosition
     | AttributeResizeEnded Model.Table.ResizeOp MousePosition
@@ -84,6 +93,7 @@ dndSystemFile tableType =
 type alias Model =
     { config : Config
     , rtorrentSystemInfo : Maybe Model.Rtorrent.Info
+    , top : Float
     , dnd : DnDList.Model
     , websocketConnected : Bool
     , contextMenu : Maybe ContextMenu
@@ -114,6 +124,11 @@ setConfig new model =
 
     else
         model
+
+
+setTop : Float -> Model -> Model
+setTop new model =
+    { model | top = new }
 
 
 setDnd : DnDList.Model -> Model -> Model

--- a/frontend/src/Update.elm
+++ b/frontend/src/Update.elm
@@ -49,6 +49,9 @@ update msg model =
         SetTimeZone zone ->
             r |> andThen (call setTimeZone zone)
 
+        Scroll scrollEvent ->
+            r |> andThen (call setTop scrollEvent.scrollTop)
+
         MouseDown attribute pos button keys ->
             r |> andThen (handleMouseDown attribute pos button keys)
 


### PR DESCRIPTION
With many hundreds of rows, the torrent table gets a bit sluggish, especially when changing column ordering and sorting.

This only renders rows that are visible on screen, which makes it feel a lot faster.

There are some negative side effects - during fast scrolling you can see some redraws, so I'll probably make this an option.